### PR TITLE
deny social media links

### DIFF
--- a/newsSpiders/spiders/discover_article_spider.py
+++ b/newsSpiders/spiders/discover_article_spider.py
@@ -33,7 +33,8 @@ class DiscoverNewArticlesSpider(CrawlSpider):
             "facebook.com",
             "twitter.com",
             "linkedin.com",
-            "plurk.com" "line.me",
+            "plurk.com",
+            "line.me",
             "line.naver.jp",
             "plus.google.com",
         ]


### PR DESCRIPTION
for issue #43 

- remove 'follow=True' for articles because the social media share links is usually in article page.
- add social media domain to 'deny' rules