### PR TITLE
add site_id to crawler stats of discover spider

### DIFF
--- a/newsSpiders/runner/discover.py
+++ b/newsSpiders/runner/discover.py
@@ -31,15 +31,18 @@ def run(runner, site_id, args=None):
     }
 
     if "dcard" in site_url:
+        crawler = Crawler(DiscoverDcardPostsSpider, settings)
+        crawler.stats.set_value("site_id", site_id)
+
         runner.crawl(
-            Crawler(DiscoverDcardPostsSpider, settings),
-            site_id=site_id,
-            site_url=site_url,
-            site_type=site_type,
+            crawler, site_id=site_id, site_url=site_url, site_type=site_type,
         )
     else:
+        crawler = Crawler(DiscoverNewArticlesSpider, settings)
+        crawler.stats.set_value("site_id", site_id)
+
         runner.crawl(
-            Crawler(DiscoverNewArticlesSpider, settings),
+            crawler,
             site_id=site_id,
             site_url=site_url,
             site_type=site_type,


### PR DESCRIPTION
issue #58 

site_id 在倒數第二行
```python
2020-02-05 16:27:08 [scrapy.statscollectors] INFO: Dumping Scrapy stats:
{'downloader/request_bytes': 105848,
 'downloader/request_count': 201,
 'downloader/request_method_count/GET': 201,
 'downloader/response_bytes': 563692,
 'downloader/response_count': 201,
 'downloader/response_status_count/200': 201,
 'elapsed_time_seconds': 375.036076,
 'finish_reason': 'finished',
 'finish_time': datetime.datetime(2020, 2, 5, 21, 27, 8, 247958),
 'item_scraped_count': 100,
 'log_count/INFO': 19,
 'memusage/max': 67772416,
 'memusage/startup': 61181952,
 'request_depth_max': 2,
 'response_received_count': 201,
 'scheduler/dequeued': 201,
 'scheduler/dequeued/memory': 201,
 'scheduler/enqueued': 201,
 'scheduler/enqueued/memory': 201,
 'site_id': 493,
 'start_time': datetime.datetime(2020, 2, 5, 21, 20, 53, 211882)}
```